### PR TITLE
examples(next): prebuild navigation-ponyfill

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "npm run build --prefix ../../packages/navigation-ponyfill",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
Fixes deployments on Vercel.

Deployments to Vercel failed because `navigation-ponyfill` must be built prior to building the example app.